### PR TITLE
README: fix relative link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Installation
 1. Install the Calibre plugin:
-   1. Download the [latest release](releases/latest).
+   1. Download the [latest release](https://github.com/iamwillbar/calibre-plugin-readwise/releases/latest).
    1. Open Calibre.
    1. Click Preferences and then Plugins.
    1. Click Load Plugin From File and then select the release you downloaded above.


### PR DESCRIPTION
The relative link we 404'ing for me and directing to https://github.com/iamwillbar/calibre-plugin-readwise/blob/main/releases/latest